### PR TITLE
Improve cross-platform path handling

### DIFF
--- a/src/adapters/csv_writer.py
+++ b/src/adapters/csv_writer.py
@@ -1,11 +1,12 @@
 """Adapters for writing OCR results."""
+
 import csv
-import os
+from pathlib import Path
 
 def write_ocr_results(results, output_csv):
     """Write OCR output records to a CSV file."""
-    with open(output_csv, "w", encoding="utf-8", newline='') as f:
+    with open(output_csv, "w", encoding="utf-8", newline="") as f:
         writer = csv.writer(f)
         writer.writerow(["filename", "text", "validation"])
         for path, text, verdicts in results:
-            writer.writerow([os.path.basename(path), text, verdicts])
+            writer.writerow([Path(path).name, text, verdicts])

--- a/src/cli.py
+++ b/src/cli.py
@@ -1,5 +1,7 @@
 """Command-line interface for the OCR pipeline."""
 import argparse
+from pathlib import Path
+
 from .modules.logging_utils import setup_logging
 from .app import run_ocr_pipeline
 
@@ -22,7 +24,8 @@ def main():
     """Entry point used by console scripts."""
     setup_logging()
     args = parse_args()
-    run_ocr_pipeline(args.input, args.output, args.validation)
+    output = str(Path(args.output).expanduser())
+    run_ocr_pipeline(args.input, output, args.validation)
 
 if __name__ == "__main__":
     main()

--- a/src/modules/file_utils.py
+++ b/src/modules/file_utils.py
@@ -1,25 +1,33 @@
 """Utilities for locating image files on disk."""
-import os
-from typing import List
 
-SUPPORTED_EXTENSIONS = ('.png', '.jpg', '.jpeg', '.bmp', '.tiff', '.gif')
+from pathlib import Path
+from typing import Iterable, List
+
+SUPPORTED_EXTENSIONS = (".png", ".jpg", ".jpeg", ".bmp", ".tiff", ".gif")
 
 def is_image_file(filename: str) -> bool:
-    """Return True if the filename has a supported image extension."""
+    """Return ``True`` if ``filename`` has a supported image extension."""
     return filename.lower().endswith(SUPPORTED_EXTENSIONS)
 
-def collect_image_files(inputs: List[str]) -> List[str]:
-    """Collect all image file paths from given directories or files."""
-    image_files = []
-    for input_path in inputs:
-        if os.path.isdir(input_path):
-            for fname in os.listdir(input_path):
-                fpath = os.path.join(input_path, fname)
-                if os.path.isfile(fpath) and is_image_file(fname):
-                    image_files.append(fpath)
-        elif os.path.isfile(input_path) and is_image_file(input_path):
-            image_files.append(input_path)
+def collect_image_files(inputs: Iterable[str]) -> List[str]:
+    """Collect all image file paths from given directories or files.
+
+    This function accepts any iterable of input paths and handles Windows or
+    POSIX-style paths transparently using :class:`pathlib.Path`.
+    """
+
+    image_files: List[str] = []
+    for raw_path in inputs:
+        p = Path(raw_path).expanduser()
+        if p.is_dir():
+            for child in p.iterdir():
+                if child.is_file() and is_image_file(child.name):
+                    image_files.append(str(child))
+        elif p.is_file() and is_image_file(p.name):
+            image_files.append(str(p))
         else:
             from logging import warning
-            warning(f"Skipping unsupported input: {input_path}")
+
+            warning(f"Skipping unsupported input: {raw_path}")
+
     return image_files

--- a/tests/test_windows_fs.py
+++ b/tests/test_windows_fs.py
@@ -1,0 +1,36 @@
+from pyfakefs.fake_filesystem_unittest import Patcher
+
+from src.modules.file_utils import collect_image_files
+from src.adapters.csv_writer import write_ocr_results
+
+
+def test_collect_image_files_on_windows():
+    with Patcher() as patcher:
+        fs = patcher.fs
+        fs.is_windows_fs = True
+        fs.path_separator = '\\'
+        fs.reset()
+        fs.create_dir(r'C:\images')
+        fs.create_file(r'C:\images\img1.jpg')
+        fs.create_file(r'C:\images\img2.png')
+
+        files = collect_image_files([r'C:\images'])
+        assert set(files) == {r'C:\images\img1.jpg', r'C:\images\img2.png'}
+
+
+def test_write_ocr_results_on_windows():
+    with Patcher() as patcher:
+        fs = patcher.fs
+        fs.is_windows_fs = True
+        fs.path_separator = '\\'
+        fs.reset()
+        out_dir = r'C:\out'
+        fs.create_dir(out_dir)
+        csv_file = rf'{out_dir}\results.csv'
+        results = [(r'C:\images\img1.jpg', 'hello', 'OK')]
+        write_ocr_results(results, csv_file)
+        with open(csv_file, 'r', encoding='utf-8') as f:
+            content = f.read()
+        assert 'filename,text,validation' in content
+        assert 'img1.jpg' in content
+


### PR DESCRIPTION
## Summary
- use `pathlib.Path` in CLI, CSV writer, and file utilities
- add expansion of user paths for output file
- add pyfakefs tests to simulate Windows paths

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687b0b1c0a50832ca33d5d0e5d2a315b