### PR TITLE
Add Windows quickstart and packaging improvements

### DIFF
--- a/QUICKSTART.txt
+++ b/QUICKSTART.txt
@@ -1,0 +1,8 @@
+Install and run the OCR CLI with these steps on Windows:
+
+1. Open Command Prompt.
+2. Run `install.bat` from this folder to set up a virtual environment and install the package.
+3. After installation, call the tool with `ocrcli <images> -o output.csv`.
+
+The installer uses Python and pip, so ensure Python 3.8+ is installed from
+https://www.python.org/downloads/windows/ .

--- a/install.bat
+++ b/install.bat
@@ -1,0 +1,11 @@
+@echo off
+REM Simple installer for ocrcli on Windows
+python -m venv venv
+call venv\Scripts\activate.bat
+pip install --upgrade pip
+pip install -r requirements.txt
+pip install .
+
+echo.
+echo Installation complete. Run the CLI with:
+echo ocrcli [images...] -o output.csv

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,2 +1,6 @@
 [tool.pytest.ini_options]
 pythonpath = "."
+
+[build-system]
+requires = ["setuptools", "wheel"]
+build-backend = "setuptools.build_meta"

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,33 @@
+"""Packaging configuration for the ocrcli project."""
+
+from pathlib import Path
+from setuptools import setup, find_packages
+
+# Read the requirements from requirements.txt
+reqs_path = Path(__file__).resolve().with_name("requirements.txt")
+install_requires = [
+    line.strip()
+    for line in reqs_path.read_text().splitlines()
+    if line.strip() and not line.startswith("#")
+]
+
+setup(
+    name='ocrcli',
+    version='0.1.0',
+    packages=find_packages('src'),
+    package_dir={'': 'src'},
+    include_package_data=True,
+    install_requires=install_requires,
+    entry_points={
+        'console_scripts': [
+            'ocrcli=src.cli:main',
+        ],
+    },
+    description='Command-line OCR pipeline.',
+    python_requires='>=3.8',
+    classifiers=[
+        'Programming Language :: Python :: 3',
+        'License :: OSI Approved :: MIT License',
+        'Operating System :: OS Independent',
+    ],
+)

--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,7 @@ setup(
     install_requires=install_requires,
     entry_points={
         'console_scripts': [
-            'ocrcli=src.cli:main',
+            'ocrcli=cli:main',
         ],
     },
     description='Command-line OCR pipeline.',


### PR DESCRIPTION
## Summary
- package modules using the src layout
- add `install.bat` helper for Windows users
- provide concise `QUICKSTART.txt` instructions

## Testing
- `pip install pyfakefs`
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687b103465e0832c8bf4fd7538292286